### PR TITLE
docs: update OWNERS and MAINTAINERS per argoproj/argoproj#455

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,7 +19,7 @@ If this file and that one differ, then the argoproj file is the authoritative ve
 | Tim Collins               | [tico24](https://github.com/tico24)               | Approver(docs) | Independent                                    |
 | Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)   | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
 | Alex Collins              | [alexec](https://github.com/alexec)               | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
-| Ed Lee                    | [edlee2121](https://github.com/edlee2121)         | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
+| Ed Lee                    | [edlee2121](https://github.com/edlee2121)         | Reviewer       | Independent                                    |
 | William Van Hevelingen    | [blkperl](https://github.com/blkperl)             | Reviewer       | [Acquia](https://www.acquia.com/)              |
 | Yucong Wang               | [jswxstw](https://github.com/jswxstw)             | Reviewer       | Independent                                    |
 | Eduardo Rodrigues         | [eduardodbr](https://github.com/eduardodbr)       | Reviewer       | Independent                                    |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,15 +11,15 @@ If this file and that one differ, then the argoproj file is the authoritative ve
 |---------------------------|---------------------------------------------------|----------------------------|------------------------------------------------|
 | Alan Clucas               | [Joibel](https://github.com/Joibel)               | Lead           | [Pipekit](https://pipekit.io/)                 |
 | Yuan Tang                 | [terrytangyuan](https://github.com/terrytangyuan) | Lead           | [Red Hat](https://www.redhat.com)              |
-| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)   | Approver       | [Intuit](https://www.github.com/intuit/)       |
-| Alex Collins              | [alexec](https://github.com/alexec)               | Approver       | [Intuit](https://www.github.com/intuit/)       |
-| Ed Lee                    | [edlee2121](https://github.com/edlee2121)         | Approver       | [Intuit](https://www.github.com/intuit/)       |
 | Mason Malone              | [MasonM](https://github.com/MasonM)               | Approver       | [Adobe](https://www.github.com/adobe/)         |
 | Isitha Subasinghe         | [isubasinghe](https://github.com/isubasinghe)     | Approver       | [Pipekit](https://pipekit.io/)                 |
 | Jesse Suen                | [jessesuen](https://github.com/jessesuen)         | Approver       | [Akuity](https://akuity.io/)                   |
 | Julie Vogelman            | [juliev0](https://github.com/juliev0)             | Approver       | [Intuit](https://www.github.com/intuit/)       |
 | Tianchu Zhao              | [tczhao](https://github.com/tczhao)               | Approver       | [Atlan](https://atlan.com/)                    |
 | Tim Collins               | [tico24](https://github.com/tico24)               | Approver(docs) | Independent                                    |
+| Saravanan Balasubramanian | [sarabala1979](https://github.com/sarabala1979)   | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
+| Alex Collins              | [alexec](https://github.com/alexec)               | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
+| Ed Lee                    | [edlee2121](https://github.com/edlee2121)         | Reviewer       | [Intuit](https://www.github.com/intuit/)       |
 | William Van Hevelingen    | [blkperl](https://github.com/blkperl)             | Reviewer       | [Acquia](https://www.acquia.com/)              |
 | Yucong Wang               | [jswxstw](https://github.com/jswxstw)             | Reviewer       | Independent                                    |
 | Eduardo Rodrigues         | [eduardodbr](https://github.com/eduardodbr)       | Reviewer       | Independent                                    |

--- a/OWNERS
+++ b/OWNERS
@@ -3,18 +3,18 @@ owners:
 - terrytangyuan
 
 approvers:
-- alexec
 - alexmt
-- edlee2121
 - isubasinghe
 - jessesuen
 - juliev0
 - masonm
-- sarabala1979
 - tczhao
 
 reviewers:
+- alexec
 - blkperl
 - eduardodbr
+- edlee2121
 - jswxstw
+- sarabala1979
 - shuangkun


### PR DESCRIPTION
## Summary

Updates `OWNERS` and `MAINTAINERS.md` to bring this repository in line with the membership changes for Argo Workflows in [argoproj/argoproj#455](https://github.com/argoproj/argoproj/pull/455) (the authoritative maintainers list).

Workflows-relevant role changes from that PR:

| Maintainer | GitHub | Before | After |
|---|---|---|---|
| Saravanan Balasubramanian | sarabala1979 | Approver | Reviewer |
| Alex Collins | alexec | Approver | Reviewer |
| Ed Lee | edlee2121 | Approver | Reviewer |
| Tim Collins | tico24 | Reviewer(docs) | Approver(docs) |

## Changes

- **`OWNERS`**: moved `alexec`, `edlee2121`, and `sarabala1979` from `approvers` to `reviewers`.
- **`MAINTAINERS.md`**: updated the roles for the three demoted maintainers to `Reviewer` and regrouped the table so it stays ordered by role.

`tico24`'s promotion to `Approver(docs)` was already reflected in the local `MAINTAINERS.md`, so no change was needed there.

https://claude.ai/code/session_01ATt4hEQ1e2wQk6ksifFdDQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATt4hEQ1e2wQk6ksifFdDQ)_