### PR TITLE
chore: enable CodeRabbit auto-reviews on main, excluding dependency PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,7 +37,14 @@ reviews:
     - "!**/sdks/python/client/**"
 
   auto_review:
-    enabled: false
+    # Automatically review PRs targeting the default branch (main).
+    # base_branches is intentionally left empty so only main is covered.
+    enabled: true
+
+    # Skip PRs labelled as dependency updates (dependabot/renovate use
+    # the "type/dependencies" label). The "!" prefix is a negative match.
+    labels:
+      - "!type/dependencies"
 
   # Tools configuration
   tools:


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

### Motivation

We want CodeRabbit to automatically review pull requests targeting `main`, without spending review cycles on automated dependency-update PRs (opened by Dependabot and Renovate).

### Modifications

In `.coderabbit.yaml`, updated the `reviews.auto_review` block:

- Set `enabled: true` so PRs targeting the default branch (`main`) are reviewed automatically. `base_branches` is intentionally left empty, so only `main` is covered (not the `release-*` branches Renovate also targets).
- Added `labels: ["!type/dependencies"]`. The `!` prefix is a negative match, so PRs carrying the `type/dependencies` label are skipped. Both `.github/dependabot.yml` and `renovate.json` apply that label to their PRs.

### Verification

- Validated the file parses as YAML.
- Confirmed the field names (`enabled`, `labels`, negative `!` label matching, `base_branches` semantics) against the CodeRabbit v2 configuration schema.
- Confirmed the dependency-update label is `type/dependencies` by inspecting `.github/dependabot.yml` and `renovate.json`.

### Documentation

Not needed — this is a repository automation config change with no user-facing surface. The behaviour is documented inline via comments in `.coderabbit.yaml`.

### AI

This PR was prepared with the assistance of Claude Code (generative AI), including the config change, commit message, and this description. All changes were reviewed before submission.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZT79cJLaGeqCnG4tk7ehP)_