### PR TITLE
fix(controller): replace configmap watchers with informers

### DIFF
--- a/workflow/controller/cache_gc.go
+++ b/workflow/controller/cache_gc.go
@@ -26,7 +26,7 @@ func init() {
 // syncAllCacheForGC syncs all cache for GC
 func (wfc *WorkflowController) syncAllCacheForGC(ctx context.Context) {
 	logger := logging.RequireLoggerFromContext(ctx)
-	configMaps, err := wfc.configMapInformer.GetIndexer().ByIndex(indexes.ConfigMapLabelsIndex, common.LabelValueTypeConfigMapCache)
+	configMaps, err := wfc.typedConfigMapInformer.GetIndexer().ByIndex(indexes.ConfigMapLabelsIndex, common.LabelValueTypeConfigMapCache)
 	if err != nil {
 		logger.WithError(err).Error(ctx, "Failed to get configmaps from informer")
 		return

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -121,12 +121,14 @@ type WorkflowController struct {
 	maxStackDepth int
 
 	// datastructures to support the processing of workflows and workflow pods
-	wfInformer        cache.SharedIndexInformer
-	nsInformer        cache.SharedIndexInformer
-	wftmplInformer    wfextvv1alpha1.WorkflowTemplateInformer
-	cwftmplInformer   wfextvv1alpha1.ClusterWorkflowTemplateInformer
-	PodController     *pod.Controller // Currently public for woc to access, but would rather an accessor
-	configMapInformer cache.SharedIndexInformer
+	wfInformer      cache.SharedIndexInformer
+	nsInformer      cache.SharedIndexInformer
+	wftmplInformer  wfextvv1alpha1.WorkflowTemplateInformer
+	cwftmplInformer wfextvv1alpha1.ClusterWorkflowTemplateInformer
+	PodController   *pod.Controller // Currently public for woc to access, but would rather an accessor
+	// typedConfigMapInformer watches configmaps labelled with workflows.argoproj.io/configmap-type,
+	// used to resolve parameters sourced from configmaps and to GC memoization caches
+	typedConfigMapInformer cache.SharedIndexInformer
 	// controllerConfigMapInformer watches the controller's own configmap to reload configuration on change
 	controllerConfigMapInformer cache.SharedIndexInformer
 	// semaphoreConfigMapInformer watches configmaps in the managed namespace to requeue workflows waiting on a semaphore whose configuration changed
@@ -353,7 +355,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 
 	wfc.updateEstimatorFactory(ctx)
 
-	wfc.configMapInformer = wfc.newConfigMapInformer(ctx)
+	wfc.typedConfigMapInformer = wfc.newTypedConfigMapInformer(ctx)
 
 	// Create Synchronization Manager
 	wfc.createSynchronizationManager(ctx)
@@ -374,7 +376,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 
 	go wfc.wfInformer.Run(ctx.Done())
 	go wfc.wftmplInformer.Informer().Run(ctx.Done())
-	go wfc.configMapInformer.Run(ctx.Done())
+	go wfc.typedConfigMapInformer.Run(ctx.Done())
 	go wfc.wfTaskSetInformer.Informer().Run(ctx.Done())
 	go wfc.artGCTaskInformer.Informer().Run(ctx.Done())
 	go wfc.taskResultInformer.Run(ctx.Done())
@@ -389,7 +391,7 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		nsInformerHasSynced,
 		wfc.wftmplInformer.Informer().HasSynced,
 		wfc.PodController.HasSynced(),
-		wfc.configMapInformer.HasSynced,
+		wfc.typedConfigMapInformer.HasSynced,
 		controllerConfigMapInformerHasSynced,
 		semaphoreConfigMapInformerHasSynced,
 		wfc.wfTaskSetInformer.Informer().HasSynced,
@@ -1248,7 +1250,7 @@ func (wfc *WorkflowController) instanceIDReq() labels.Requirement {
 	return util.InstanceIDRequirement(wfc.Config.InstanceID)
 }
 
-func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.SharedIndexInformer {
+func (wfc *WorkflowController) newTypedConfigMapInformer(ctx context.Context) cache.SharedIndexInformer {
 	indexInformer := v1.NewFilteredConfigMapInformer(wfc.kubeclientset, wfc.GetManagedNamespace(), configMapResyncPeriod, cache.Indexers{
 		indexes.ConfigMapLabelsIndex: indexes.ConfigMapIndexFunc,
 	}, func(opts *metav1.ListOptions) {

--- a/workflow/controller/controller.go
+++ b/workflow/controller/controller.go
@@ -22,13 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	v1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	apiwatch "k8s.io/client-go/tools/watch"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/argoproj/argo-workflows/v4/util/logging"
@@ -123,30 +121,34 @@ type WorkflowController struct {
 	maxStackDepth int
 
 	// datastructures to support the processing of workflows and workflow pods
-	wfInformer            cache.SharedIndexInformer
-	nsInformer            cache.SharedIndexInformer
-	wftmplInformer        wfextvv1alpha1.WorkflowTemplateInformer
-	cwftmplInformer       wfextvv1alpha1.ClusterWorkflowTemplateInformer
-	PodController         *pod.Controller // Currently public for woc to access, but would rather an accessor
-	configMapInformer     cache.SharedIndexInformer
-	wfQueue               workqueue.TypedRateLimitingInterface[string]
-	wfArchiveQueue        workqueue.TypedRateLimitingInterface[string]
-	throttler             sync.Throttler
-	workflowKeyLock       syncpkg.KeyLock // used to lock workflows for exclusive modification or access
-	sessionProxy          *utilsqldb.SessionProxy
-	offloadNodeStatusRepo sqldb.OffloadNodeStatusRepo
-	hydrator              hydrator.Interface
-	wfArchive             sqldb.WorkflowArchive
-	estimatorFactory      estimation.EstimatorFactory
-	syncManager           *sync.Manager
-	metrics               *metrics.Metrics
-	tracing               *tracing.Tracing
-	eventRecorderManager  events.EventRecorderManager
-	archiveLabelSelector  labels.Selector
-	cacheFactory          controllercache.Factory
-	wfTaskSetInformer     wfextvv1alpha1.WorkflowTaskSetInformer
-	artGCTaskInformer     wfextvv1alpha1.WorkflowArtifactGCTaskInformer
-	taskResultInformer    cache.SharedIndexInformer
+	wfInformer        cache.SharedIndexInformer
+	nsInformer        cache.SharedIndexInformer
+	wftmplInformer    wfextvv1alpha1.WorkflowTemplateInformer
+	cwftmplInformer   wfextvv1alpha1.ClusterWorkflowTemplateInformer
+	PodController     *pod.Controller // Currently public for woc to access, but would rather an accessor
+	configMapInformer cache.SharedIndexInformer
+	// controllerConfigMapInformer watches the controller's own configmap to reload configuration on change
+	controllerConfigMapInformer cache.SharedIndexInformer
+	// semaphoreConfigMapInformer watches configmaps in the managed namespace to requeue workflows waiting on a semaphore whose configuration changed
+	semaphoreConfigMapInformer cache.SharedIndexInformer
+	wfQueue                    workqueue.TypedRateLimitingInterface[string]
+	wfArchiveQueue             workqueue.TypedRateLimitingInterface[string]
+	throttler                  sync.Throttler
+	workflowKeyLock            syncpkg.KeyLock // used to lock workflows for exclusive modification or access
+	sessionProxy               *utilsqldb.SessionProxy
+	offloadNodeStatusRepo      sqldb.OffloadNodeStatusRepo
+	hydrator                   hydrator.Interface
+	wfArchive                  sqldb.WorkflowArchive
+	estimatorFactory           estimation.EstimatorFactory
+	syncManager                *sync.Manager
+	metrics                    *metrics.Metrics
+	tracing                    *tracing.Tracing
+	eventRecorderManager       events.EventRecorderManager
+	archiveLabelSelector       labels.Selector
+	cacheFactory               controllercache.Factory
+	wfTaskSetInformer          wfextvv1alpha1.WorkflowTaskSetInformer
+	artGCTaskInformer          wfextvv1alpha1.WorkflowArtifactGCTaskInformer
+	taskResultInformer         cache.SharedIndexInformer
 
 	// progressPatchTickDuration defines how often the executor will patch pod annotations if an updated progress is found.
 	// Default is 1m and can be configured using the env var ARGO_PROGRESS_PATCH_TICK_DURATION.
@@ -169,6 +171,7 @@ const (
 	clusterWorkflowTemplateResyncPeriod = 20 * time.Minute
 	workflowExistenceCheckPeriod        = 1 * time.Minute
 	workflowTaskSetResyncPeriod         = 20 * time.Minute
+	configMapResyncPeriod               = 20 * time.Minute
 )
 
 var (
@@ -360,19 +363,14 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 	}
 
 	if os.Getenv("WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS") != "false" {
-		go wfc.runConfigMapWatcher(ctx)
+		wfc.controllerConfigMapInformer = wfc.newControllerConfigMapInformer(ctx)
+		wfc.semaphoreConfigMapInformer = wfc.newSemaphoreConfigMapInformer(ctx)
 	}
 
 	// namespace informer only works if has RBAC access
-	var nsInformerHasSynced func() bool
-	if wfc.nsInformer != nil {
-		go wfc.nsInformer.Run(ctx.Done())
-		nsInformerHasSynced = wfc.nsInformer.HasSynced
-	} else {
-		nsInformerHasSynced = func() bool {
-			return true
-		}
-	}
+	nsInformerHasSynced := startOptionalInformer(ctx, wfc.nsInformer)
+	controllerConfigMapInformerHasSynced := startOptionalInformer(ctx, wfc.controllerConfigMapInformer)
+	semaphoreConfigMapInformerHasSynced := startOptionalInformer(ctx, wfc.semaphoreConfigMapInformer)
 
 	go wfc.wfInformer.Run(ctx.Done())
 	go wfc.wftmplInformer.Informer().Run(ctx.Done())
@@ -392,6 +390,8 @@ func (wfc *WorkflowController) Run(ctx context.Context, wfWorkers, workflowTTLWo
 		wfc.wftmplInformer.Informer().HasSynced,
 		wfc.PodController.HasSynced(),
 		wfc.configMapInformer.HasSynced,
+		controllerConfigMapInformerHasSynced,
+		semaphoreConfigMapInformerHasSynced,
 		wfc.wfTaskSetInformer.Informer().HasSynced,
 		wfc.artGCTaskInformer.Informer().HasSynced,
 		wfc.taskResultInformer.HasSynced,
@@ -514,52 +514,106 @@ func (wfc *WorkflowController) initManagers(ctx context.Context) error {
 	return nil
 }
 
-func (wfc *WorkflowController) runConfigMapWatcher(ctx context.Context) {
-	defer runtimeutil.HandleCrashWithContext(ctx, runtimeutil.PanicHandlers...)
-	ctx, logger := logging.RequireLoggerFromContext(ctx).WithField("component", "configmap_watcher").InContext(ctx)
-	controllerConfigWatcher, err := apiwatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
-		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.configController.GetNamespace()).Watch(ctx, metav1.ListOptions{
-				FieldSelector: fmt.Sprintf("metadata.name=%s", wfc.configController.GetName()),
-			})
-		},
+// newControllerConfigMapInformer returns an informer for the controller's own configmap,
+// which reloads the controller configuration whenever it changes.
+func (wfc *WorkflowController) newControllerConfigMapInformer(ctx context.Context) cache.SharedIndexInformer {
+	informer := v1.NewFilteredConfigMapInformer(wfc.kubeclientset, wfc.configController.GetNamespace(), configMapResyncPeriod, cache.Indexers{}, func(opts *metav1.ListOptions) {
+		opts.FieldSelector = fmt.Sprintf("metadata.name=%s", wfc.configController.GetName())
 	})
-	if err != nil {
-		panic(err)
-	}
-	defer controllerConfigWatcher.Stop()
-	semaphoreConfigWatcher, err := apiwatch.NewRetryWatcherWithContext(ctx, "1", &cache.ListWatch{
-		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return wfc.kubeclientset.CoreV1().ConfigMaps(wfc.GetManagedNamespace()).Watch(ctx, metav1.ListOptions{})
-		},
-	})
-	if err != nil {
-		panic(err)
-	}
-	defer semaphoreConfigWatcher.Stop()
-
-	for {
-		select {
-		case event := <-controllerConfigWatcher.ResultChan():
-			cm, ok := event.Object.(*apiv1.ConfigMap)
-			if !ok {
-				logger.Error(ctx, "invalid config map object received in config watcher. Ignored processing")
-				continue
+	ctx, logger := logging.RequireLoggerFromContext(ctx).WithField("component", "config_watcher").InContext(ctx)
+	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
+	informer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+		// AddFunc covers the configmap being recreated after a deletion; adds from the
+		// informer's initial sync are skipped as the configuration is loaded at startup
+		AddFunc: func(obj any, isInInitialList bool) {
+			if isInInitialList {
+				return
 			}
-			logger.WithFields(logging.Fields{"namespace": cm.Namespace, "name": cm.Name}).Info(ctx, "Received Workflow Controller config map update")
+			cm := obj.(*apiv1.ConfigMap)
+			logger.WithFields(logging.Fields{"namespace": cm.Namespace, "name": cm.Name}).Info(ctx, "Received Workflow Controller config map creation")
 			wfc.UpdateConfig(ctx)
-		case event := <-semaphoreConfigWatcher.ResultChan():
-			cm, ok := event.Object.(*apiv1.ConfigMap)
-			if !ok {
-				logger.Error(ctx, "invalid config map object received in semaphore config watcher. Ignored processing")
-				continue
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			oldCM := oldObj.(*apiv1.ConfigMap)
+			newCM := newObj.(*apiv1.ConfigMap)
+			if oldCM.ResourceVersion == newCM.ResourceVersion {
+				return
 			}
-			logger.WithFields(logging.Fields{"namespace": cm.Namespace, "name": cm.Name}).Debug(ctx, "received config map update")
-			wfc.notifySemaphoreConfigUpdate(ctx, cm)
-		case <-ctx.Done():
-			return
-		}
+			logger.WithFields(logging.Fields{"namespace": newCM.Namespace, "name": newCM.Name}).Info(ctx, "Received Workflow Controller config map update")
+			wfc.UpdateConfig(ctx)
+		},
+	})
+	return informer
+}
+
+// startOptionalInformer runs an informer that may not have been created (due to
+// configuration or RBAC restrictions), returning its HasSynced, or a function that
+// reports synced when there is no informer to wait for.
+func startOptionalInformer(ctx context.Context, informer cache.SharedIndexInformer) func() bool {
+	if informer == nil {
+		return func() bool { return true }
 	}
+	go informer.Run(ctx.Done())
+	return informer.HasSynced
+}
+
+// newSemaphoreConfigMapInformer returns an informer for configmaps in the managed namespace,
+// which requeues workflows waiting on a semaphore whose configuration changed.
+func (wfc *WorkflowController) newSemaphoreConfigMapInformer(ctx context.Context) cache.SharedIndexInformer {
+	informer := v1.NewConfigMapInformer(wfc.kubeclientset, wfc.GetManagedNamespace(), configMapResyncPeriod, cache.Indexers{})
+	// This informer watches all configmaps in the managed namespace, as semaphore configmaps
+	// cannot be identified by a label selector. Only identifying metadata is needed to notify
+	// waiting workflows, so strip everything else to keep the cache small.
+	//nolint:errcheck // the error only happens if the informer was already started, and it hasn't been
+	informer.SetTransform(func(obj any) (any, error) {
+		cm, ok := obj.(*apiv1.ConfigMap)
+		if !ok {
+			return obj, nil
+		}
+		return &apiv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Namespace:       cm.Namespace,
+			Name:            cm.Name,
+			ResourceVersion: cm.ResourceVersion,
+		}}, nil
+	})
+	ctx, logger := logging.RequireLoggerFromContext(ctx).WithField("component", "semaphore_config_watcher").InContext(ctx)
+	//nolint:errcheck // the error only happens if the informer was stopped, and it hasn't even started (https://github.com/kubernetes/client-go/blob/46588f2726fa3e25b1704d6418190f424f95a990/tools/cache/shared_informer.go#L580)
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		// AddFunc fires for every configmap on the informer's initial sync, and afterwards for
+		// newly created configmaps, covering semaphore configmaps created after workflows
+		// started waiting on them
+		AddFunc: func(obj any) {
+			cm := obj.(*apiv1.ConfigMap)
+			wfc.notifySemaphoreConfigUpdate(ctx, cm)
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			oldCM := oldObj.(*apiv1.ConfigMap)
+			newCM := newObj.(*apiv1.ConfigMap)
+			if oldCM.ResourceVersion == newCM.ResourceVersion {
+				return
+			}
+			logger.WithFields(logging.Fields{"namespace": newCM.Namespace, "name": newCM.Name}).Debug(ctx, "received config map update")
+			wfc.notifySemaphoreConfigUpdate(ctx, newCM)
+		},
+		// DeleteFunc requeues waiting workflows so they re-evaluate promptly instead of
+		// waiting indefinitely on a semaphore whose configmap no longer exists
+		DeleteFunc: func(obj any) {
+			cm, ok := obj.(*apiv1.ConfigMap)
+			if !ok {
+				tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+				if !isTombstone {
+					return
+				}
+				cm, ok = tombstone.Obj.(*apiv1.ConfigMap)
+				if !ok {
+					return
+				}
+			}
+			logger.WithFields(logging.Fields{"namespace": cm.Namespace, "name": cm.Name}).Debug(ctx, "received config map delete")
+			wfc.notifySemaphoreConfigUpdate(ctx, cm)
+		},
+	})
+	return informer
 }
 
 // notifySemaphoreConfigUpdate will notify semaphore config update to pending workflows
@@ -1195,7 +1249,7 @@ func (wfc *WorkflowController) instanceIDReq() labels.Requirement {
 }
 
 func (wfc *WorkflowController) newConfigMapInformer(ctx context.Context) cache.SharedIndexInformer {
-	indexInformer := v1.NewFilteredConfigMapInformer(wfc.kubeclientset, wfc.GetManagedNamespace(), 20*time.Minute, cache.Indexers{
+	indexInformer := v1.NewFilteredConfigMapInformer(wfc.kubeclientset, wfc.GetManagedNamespace(), configMapResyncPeriod, cache.Indexers{
 		indexes.ConfigMapLabelsIndex: indexes.ConfigMapIndexFunc,
 	}, func(opts *metav1.ListOptions) {
 		opts.LabelSelector = common.LabelKeyConfigMapType

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -331,7 +331,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		_ = wfc.addWorkflowInformerHandlers(ctx)
 		wfc.PodController = pod.NewController(ctx, &wfc.Config, wfc.restConfig, "", wfc.kubeclientset, wfc.wfInformer, wfc.metrics, wfc.enqueueWfFromPodLabel)
 
-		wfc.configMapInformer = wfc.newConfigMapInformer(ctx)
+		wfc.typedConfigMapInformer = wfc.newTypedConfigMapInformer(ctx)
 		wfc.createSynchronizationManager(ctx)
 		_ = wfc.initManagers(ctx)
 
@@ -343,7 +343,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 		go wfc.taskResultInformer.Run(ctx.Done())
 		wfc.cwftmplInformer = informerFactory.Argoproj().V1alpha1().ClusterWorkflowTemplates()
 		go wfc.cwftmplInformer.Informer().Run(ctx.Done())
-		go wfc.configMapInformer.Run(ctx.Done())
+		go wfc.typedConfigMapInformer.Run(ctx.Done())
 		// wfc.waitForCacheSync() takes minimum 100ms, we can be faster
 		for _, c := range []cache.SharedIndexInformer{
 			wfc.wfInformer,
@@ -353,7 +353,7 @@ func newController(ctx context.Context, options ...any) (context.CancelFunc, *Wo
 			wfc.wfTaskSetInformer.Informer(),
 			wfc.artGCTaskInformer.Informer(),
 			wfc.taskResultInformer,
-			wfc.configMapInformer,
+			wfc.typedConfigMapInformer,
 		} {
 			for !c.HasSynced() {
 				time.Sleep(5 * time.Millisecond)

--- a/workflow/controller/controller_test.go
+++ b/workflow/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	gosync "sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -979,6 +981,90 @@ func TestNotifySemaphoreConfigUpdate(t *testing.T) {
 	controller.notifySemaphoreConfigUpdate(ctx, &cm)
 	time.Sleep(2 * time.Second)
 	assert.Equal(2, controller.wfQueue.Len())
+}
+
+func TestSemaphoreConfigMapInformer(t *testing.T) {
+	wf := wfv1.MustUnmarshalWorkflow(wfWithSema)
+	otherWf := wf.DeepCopy()
+	otherWf.Name = "other-wf"
+	otherWf.Spec.Synchronization.Semaphores[0].ConfigMapKeyRef.Name = "other-config"
+	ctx := logging.TestContext(t.Context())
+	cancel, controller := newController(ctx, wf, otherWf)
+	defer cancel()
+
+	require.Equal(t, 2, controller.wfQueue.Len())
+	for range 2 {
+		key, _ := controller.wfQueue.Get()
+		controller.wfQueue.Done(key)
+		controller.wfQueue.Forget(key)
+	}
+
+	cm := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-config", Namespace: "default", ResourceVersion: "1", Labels: map[string]string{"argo": "config"}},
+		Data:       map[string]string{"workflow": "1"},
+	}
+	_, err := controller.kubeclientset.CoreV1().ConfigMaps("default").Create(ctx, cm, metav1.CreateOptions{})
+	require.NoError(t, err)
+	otherCM := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-config", Namespace: "default", ResourceVersion: "1"},
+		Data:       map[string]string{"workflow": "1"},
+	}
+	_, err = controller.kubeclientset.CoreV1().ConfigMaps("default").Create(ctx, otherCM, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// signal once the informer's watch is established so the update below cannot race it
+	watchEstablished := make(chan struct{})
+	var watchOnce gosync.Once
+	fakeClient := controller.kubeclientset.(*fake.Clientset)
+	fakeClient.PrependWatchReactor("configmaps", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		w, err := fakeClient.Tracker().Watch(action.GetResource(), action.GetNamespace())
+		if err != nil {
+			return false, nil, err
+		}
+		watchOnce.Do(func() { close(watchEstablished) })
+		return true, w, nil
+	})
+
+	informer := controller.newSemaphoreConfigMapInformer(ctx)
+	go informer.Run(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.HasSynced))
+
+	// the add events from the initial sync notify the workflows waiting on the semaphores
+	require.Eventually(t, func() bool { return controller.wfQueue.Len() == 2 }, 10*time.Second, 100*time.Millisecond)
+	for range 2 {
+		key, _ := controller.wfQueue.Get()
+		controller.wfQueue.Done(key)
+		controller.wfQueue.Forget(key)
+	}
+
+	// the transform keeps only identifying metadata in the cache
+	obj, exists, err := informer.GetStore().GetByKey("default/my-config")
+	require.NoError(t, err)
+	require.True(t, exists)
+	cached, ok := obj.(*apiv1.ConfigMap)
+	require.True(t, ok)
+	assert.Equal(t, "my-config", cached.Name)
+	assert.Equal(t, "default", cached.Namespace)
+	assert.Equal(t, "1", cached.ResourceVersion)
+	assert.Empty(t, cached.Data)
+	assert.Empty(t, cached.Labels)
+
+	select {
+	case <-watchEstablished:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the informer's watch to be established")
+	}
+	cm.ResourceVersion = "2"
+	cm.Data["workflow"] = "2"
+	_, err = controller.kubeclientset.CoreV1().ConfigMaps("default").Update(ctx, cm, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// the update event notifies only the workflow waiting on the updated semaphore
+	require.Eventually(t, func() bool { return controller.wfQueue.Len() == 1 }, 10*time.Second, 100*time.Millisecond)
+	key, _ := controller.wfQueue.Get()
+	assert.Equal(t, "default/hello-world", key)
+	controller.wfQueue.Done(key)
+	controller.wfQueue.Forget(key)
 }
 
 func TestParallelismWithInitializeRunningWorkflows(t *testing.T) {

--- a/workflow/controller/dag.go
+++ b/workflow/controller/dag.go
@@ -463,7 +463,7 @@ func (woc *wfOperationCtx) executeDAGTask(ctx context.Context, dagCtx *dagContex
 			}
 		}
 
-		processedTmpl, err := common.ProcessArgs(ctx, tmpl, &task.Arguments, woc.globalParams, map[string]string{}, true, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
+		processedTmpl, err := common.ProcessArgs(ctx, tmpl, &task.Arguments, woc.globalParams, map[string]string{}, true, woc.wf.Namespace, woc.controller.typedConfigMapInformer.GetIndexer())
 		if err != nil {
 			woc.markNodeError(ctx, node.Name, err)
 		}

--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -667,7 +667,7 @@ func (woc *wfOperationCtx) setGlobalParameters(executionParameters wfv1.Argument
 		case param.Value != nil:
 			woc.globalParams["workflow.parameters."+param.Name] = param.Value.String()
 		case param.ValueFrom != nil && param.ValueFrom.ConfigMapKeyRef != nil:
-			cmValue, err := common.GetConfigMapValue(woc.controller.configMapInformer.GetIndexer(), woc.wf.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
+			cmValue, err := common.GetConfigMapValue(woc.controller.typedConfigMapInformer.GetIndexer(), woc.wf.Namespace, param.ValueFrom.ConfigMapKeyRef.Name, param.ValueFrom.ConfigMapKeyRef.Key)
 			if err != nil {
 				if param.ValueFrom.Default == nil {
 					return fmt.Errorf("failed to set global parameter %s from configmap with name %s and key %s: %w",
@@ -2157,7 +2157,7 @@ func (woc *wfOperationCtx) executeTemplate(ctx context.Context, nodeName string,
 	localParams["node.name"] = nodeName
 
 	// Inputs has been processed with arguments already, so pass empty arguments.
-	processedTmpl, err := common.ProcessArgs(ctx, resolvedTmpl, &args, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
+	processedTmpl, err := common.ProcessArgs(ctx, resolvedTmpl, &args, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.typedConfigMapInformer.GetIndexer())
 	if err != nil {
 		errNode := woc.initializeNodeOrMarkError(ctx, node, nodeName, templateScope, orgTmpl, opts.boundaryID, opts.nodeFlag, err)
 		return errNode, err

--- a/workflow/controller/workflowpod.go
+++ b/workflow/controller/workflowpod.go
@@ -106,7 +106,7 @@ func (woc *wfOperationCtx) processPodSpecPatch(ctx context.Context, tmpl *wfv1.T
 	for _, patch := range toProcess {
 		newTmpl := tmpl.DeepCopy()
 		newTmpl.PodSpecPatch = patch
-		processedTmpl, err := common.ProcessArgs(ctx, newTmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.configMapInformer.GetIndexer())
+		processedTmpl, err := common.ProcessArgs(ctx, newTmpl, &wfv1.Arguments{}, woc.globalParams, localParams, false, woc.wf.Namespace, woc.controller.typedConfigMapInformer.GetIndexer())
 		if err != nil {
 			return nil, errors.Wrap(err, "", "Failed to substitute the PodSpecPatch variables")
 		}


### PR DESCRIPTION
The controller and semaphore configmap watchers used a RetryWatcher
started from resourceVersion "1". When the watcher terminated (e.g. a
410 Gone from an expired resourceVersion), its result channel closed and
the select loop span on the closed channel, flooding the log with
'invalid config map object received in config watcher. Ignored
processing' and spiking CPU.

Replace both watchers with SharedIndexInformers, which re-list and
re-watch on failure. The semaphore informer strips non-identifying
fields from cached configmaps to keep memory usage down, since it must
watch all configmaps in the managed namespace. Resync events are
ignored by comparing resource versions, and a semaphore configmap
created after workflows started waiting on it now also notifies them.

Fixes #11657

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B4rcqqtAqh7dGM7nyZtCGV