### PR TITLE
ci(nix): let Renovate bump the pinned tools and fix the hashes

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -1,0 +1,50 @@
+name: Update nix hashes
+
+# Renovate bumps the pinned tool versions in flake.nix but cannot know the
+# hashes of what those versions download, so it leaves the old ones behind.
+# This puts them right on its branch, before anyone reviews the PR.
+
+on:
+  push:
+    branches:
+      - 'renovate/**'
+      - 'dependabot/**'
+    paths:
+      - 'flake.nix'
+
+permissions:
+  contents: write
+
+jobs:
+  update-hashes:
+    runs-on: ubuntu-24.04
+    env:
+      HAS_APP: ${{ secrets.NIX_UPDATE_APP_ID != '' }}
+    steps:
+      - name: Generate a token
+        id: generate-token
+        # Pushing with GITHUB_TOKEN leaves the PR's CI runs stuck in an
+        # "approval required" state, so push as a GitHub App instead.
+        # Skipped on forks without the app; the GITHUB_TOKEN fallback still
+        # pushes, it just won't re-trigger CI.
+        if: env.HAS_APP == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.NIX_UPDATE_APP_ID }}
+          private-key: ${{ secrets.NIX_UPDATE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Use the default ref (the branch that was pushed)
+          token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+      - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c # v35
+
+      - name: Update hashes
+        # Refetches every pinned download, so it takes a few minutes.
+        run: hack/nix/update-hashes.sh
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+        with:
+          commit_message: "chore(nix): update flake.nix hashes"
+          commit_options: '--signoff'
+          file_pattern: flake.nix

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -61,11 +61,15 @@ slower the first time and after each tool upgrade.
 Everything lives in `flake.nix`, in two tiers:
 
 * **Pinned.** Anything whose version is part of a contract — it decides what generated code, lint results or test
-  output look like. Each has an explicit version and hash. To upgrade one, change its entry in `toolVersions` and
-  rebuild: Nix will report the hash mismatch and print the hash to paste in. Go tools need both the source `hash` and
-  the `vendorHash` updating; the second only shows up once the first is right.
+  output look like. Each has an explicit version and hash. To upgrade one, change its entry in `toolVersions` and run
+  `hack/nix/update-hashes.sh`, which refetches what each tool downloads and writes the new hashes back. Adding a tool
+  works the same way: write `lib.fakeHash` for the hash you do not know yet and let the script fill it in.
 * **Floating.** Editors, clients and the local cluster, taken from nixpkgs as-is. These move when the `nixpkgs` input
   moves — `nix flake update` — rather than one at a time.
+
+Most of these arrive as a pull request rather than by hand. Renovate watches the `# renovate:` comments in `flake.nix`
+and bumps the versions, then a workflow runs the same script on its branch so the hashes land with it. It refreshes the
+`nixpkgs` pin weekly, which is what moves the floating tier. The few pins it deliberately leaves alone say so in place.
 
 The Go toolchain is not listed in either tier: it is read straight from the `go` directive in `go.mod`. When nixpkgs
 lags behind that version, the flake tells you to add the Go source tarball's hash to `goSrcHashes` and builds that

--- a/flake.nix
+++ b/flake.nix
@@ -32,25 +32,71 @@
       # ---------------------------------------------------------------------
       # Pinned tool versions.
       #
-      # Renovate keeps these current; each is used exactly once below, so the
-      # version and its hash sit next to each other.
+      # Renovate keeps these current: it reads the `# renovate:` comments (see
+      # renovate.json) and bumps the version, and CI then runs
+      # hack/nix/update-hashes.sh on its branch to repair the hashes below.
+      # Each version is used exactly once, so the version and its hash sit next
+      # to each other.
+      #
+      # The entries with no `# renovate:` line are deliberate, and say why: they
+      # move as part of some larger change rather than on their own.
       # ---------------------------------------------------------------------
       toolVersions = {
+        # renovate: datasource=go depName=github.com/bufbuild/buf
         buf = "1.65.0";
+
+        # Held to patch releases: the generators run against the apimachinery
+        # in go.mod, so the minor moves when that does.
+        # renovate: datasource=go depName=k8s.io/code-generator
         codeGenerator = "0.35.1";
+
+        # renovate: datasource=go depName=sigs.k8s.io/controller-tools
         controllerTools = "0.18.0";
+
+        # Not Renovate's: cspell comes from nixpkgs and the check at the bottom
+        # of this file fails if nixpkgs moves off this version, so it follows
+        # the nixpkgs input rather than a bump of its own.
         cspell = "9.7.0";
+
+        # renovate: datasource=go depName=github.com/gogo/protobuf
         gogoProtobuf = "1.3.2";
+
+        # renovate: datasource=go depName=golang.org/x/tools
         goimports = "0.35.0";
+
+        # renovate: datasource=go depName=github.com/golangci/golangci-lint/v2
         golangciLint = "2.11.3";
+
+        # renovate: datasource=go depName=github.com/go-swagger/go-swagger
         goSwagger = "0.33.1";
+
+        # renovate: datasource=go depName=gotest.tools/gotestsum
         gotestsum = "1.12.3";
+
+        # renovate: datasource=go depName=github.com/grpc-ecosystem/grpc-gateway
         grpcGateway = "1.16.0";
+
+        # renovate: datasource=go depName=github.com/kitproj/kubeauto
         kubeauto = "0.0.7";
+
+        # Not Renovate's: this is the commit the checked-in OpenAPI definitions
+        # were generated from, deliberately older than the kube-openapi in
+        # go.mod. Moving it regenerates them, so it happens with that change —
+        # and `rev` below has to move with it.
         kubeOpenapi = "0.0.0-20220124234850-424119656bbf";
+
+        # renovate: datasource=go depName=github.com/vektra/mockery/v3
         mockery = "3.5.1";
+
+        # Not Renovate's: the Java SDK it generates is what downstream users
+        # compile against, so this moves only when the SDK is regenerated on
+        # purpose and the diff reviewed.
         openapiGenerator = "5.2.1";
+
+        # renovate: datasource=pypi depName=properdocs
         properdocs = "1.6.7";
+
+        # renovate: datasource=github-releases depName=kaplanelad/snipdoc
         snipdoc = "0.1.12";
       };
 

--- a/hack/nix/update-hashes.sh
+++ b/hack/nix/update-hashes.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Repair the fixed-output hashes in flake.nix.
+#
+# Every pinned tool records the hash of something it downloads — a source
+# tarball, a vendored Go module tree, a Cargo registry snapshot — and those
+# change whenever the version does. Bump a version in `toolVersions` and run
+# this: it refetches each download and writes the new hashes back.
+#
+# CI runs it on Renovate's branches (.github/workflows/nix-hashes.yml), so a
+# version bump arrives with its hashes already correct.
+#
+# It refetches whether or not anything changed, because that is the only way to
+# be sure: a fixed-output path is named after the hash it is *expected* to have,
+# so a stale download of the old version already sits at the path the new one
+# would use, and an ordinary build would happily reuse it. A full run therefore
+# takes a few minutes; name tools as arguments to do only those.
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+flake=$repo_root/flake.nix
+cd -- "$repo_root"
+
+system=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+
+# Every hash Nix checks for us, as `<package>\t<expected hash>`. A tool that
+# does not evaluate at all — the Go overlay throws when nixpkgs lags go.mod —
+# has no hashes to fix, so it is skipped rather than taking the run down.
+# shellcheck disable=SC2016 # ${...} below is Nix interpolation, not shell
+list_hashes='
+  packages:
+  let
+    wanted = [
+      (p: p.src.outputHash or null)
+      (p: p.goModules.outputHash or null)
+      (p: p.cargoHash or null)
+    ];
+    hashesOf = name:
+      let
+        found = builtins.tryEval (builtins.concatMap
+          (where:
+            let hash = builtins.tryEval (where packages.${name}); in
+            if hash.success && builtins.isString hash.value && hash.value != ""
+            then [ "${name}\t${hash.value}" ]
+            else [ ]
+          )
+          wanted);
+      in
+      if found.success then found.value else [ ];
+  in
+  builtins.concatStringsSep "\n"
+    (builtins.concatMap hashesOf (builtins.attrNames packages))
+'
+
+if [[ $# -gt 0 ]]; then
+  tools=("$@")
+else
+  # Only the tools whose hashes are written down in flake.nix. The rest come
+  # from nixpkgs, where a hash is not ours to correct.
+  hashes=$(nix eval --raw ".#packages.$system" --apply "$list_hashes")
+  tools=()
+  while IFS=$'\t' read -r name hash; do
+    [[ -n $name ]] || continue
+    grep -q -F -- "$hash" "$flake" || continue
+    [[ " ${tools[*]} " == *" $name "* ]] || tools+=("$name")
+  done <<<"$hashes"
+
+  if [[ ${#tools[@]} -eq 0 ]]; then
+    echo "no pinned hashes found in $flake — has it been restructured?" >&2
+    exit 1
+  fi
+fi
+
+echo "refetching: ${tools[*]}"
+
+original=$(mktemp)
+trap 'rm -f "$original"' EXIT
+cp -- "$flake" "$original"
+
+for tool in "${tools[@]}"; do
+  echo "--- $tool"
+  # nix-update comes from the flake's own nixpkgs, so this needs no second
+  # nixpkgs. `--version=skip` leaves `toolVersions` alone: Renovate owns the
+  # versions, this owns the hashes underneath them.
+  nix run --inputs-from . nixpkgs#nix-update -- --flake --version=skip "$tool"
+done
+
+if diff -u --label a/flake.nix --label b/flake.nix "$original" "$flake"; then
+  echo "flake.nix hashes were already up to date"
+else
+  echo "flake.nix hashes updated, as above"
+fi

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,10 @@
     "release-4.0"
   ],
   "nix": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
   },
   "customManagers": [
     {
@@ -33,6 +36,17 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+ARG \\w+=(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "description": "Update the pinned tool versions annotated with `# renovate:` in flake.nix. The hashes underneath them are fixed up by .github/workflows/nix-hashes.yml",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)flake\\.nix$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\s+\\w+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -93,11 +107,52 @@
         "lockFileMaintenance"
       ],
       "enabled": false
+    },
+    {
+      "description": "Never automerge a pinned nix tool: the version decides what generated code, lint results or test output look like, and the hashes below it are rewritten by a follow-up commit",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchFileNames": [
+        "flake.nix"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "The code generators run against the k8s.io/apimachinery in go.mod, so their minor version moves by hand when that does",
+      "matchFileNames": [
+        "flake.nix"
+      ],
+      "matchPackageNames": [
+        "k8s.io/code-generator"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "properdocs is pinned twice, for the docs build and for the nix shell, so move both at once",
+      "matchPackageNames": [
+        "properdocs"
+      ],
+      "groupName": "properdocs"
+    },
+    {
+      "description": "The nixpkgs pin moves every floating tool at once, so it is reviewed rather than automerged",
+      "matchManagers": [
+        "nix"
+      ],
+      "automerge": false
     }
   ],
   "platformAutomerge": true,
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 4am on monday"
+    ]
   },
   "postUpdateOptions": [
     "yarnDedupeFewer",


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #46

## Chain of upstream PRs as of 2026-07-30

* PR #46:
  `nix-stack-base` ← `tb-ufbi.1-pr1`

  * **PR #53 (THIS ONE)**:
    `tb-ufbi.1-pr1` ← `tb-ufbi.8-pr8`

<!-- end git-machete generated -->

<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes #TODO

### Motivation

<!-- TODO: Say why you made your changes. -->

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

### Documentation

<!-- TODO: Say how you have updated the documentation or explain why this isn't needed here -->
<!-- Required for features: Explain how the user will discover this feature through documentation and examples -->

### AI

<!-- TODO: Declare any use of generative AI tools (for example ChatGPT) in preparing this PR, including code, tests, docs, or commit messages. Say "None" if no AI was used. -->
<!-- See the Argo project's Generative AI policy: https://github.com/argoproj/argoproj/blob/main/community/genai.md -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H871PuNyYPzjmpUhXCRXGA
