### PR TITLE
ci: enable the PR readiness helper

### DIFF
--- a/.github/pr-readiness/README.md
+++ b/.github/pr-readiness/README.md
@@ -46,9 +46,9 @@ A deterministic check ([`template.ts`](template.ts)) compares the description ag
 - PR title/body/branch are attacker-controlled: they are only ever handled as data, never interpolated into shell or scripts. The comment never echoes contributor-supplied text — only the bot's own guidance, check titles/URLs, and template section names.
 - All actions are pinned to full commit SHAs (enforced by repo lint).
 
-## Dry run & rollout
+## Dry run
 
-`DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or drafting. Roll out: merge with dry-run on → watch summaries on real PRs (correct PR resolution, author gating, sensible text) → flip to `"false"`.
+Setting `DRY_RUN: "true"` in the workflow renders the would-be comment and decisions to the job's **step summary** instead of commenting or drafting. Use it to test changes to the bot against real PRs (correct PR resolution, author gating, sensible text) without posting.
 
 ## Maintenance notes
 

--- a/.github/workflows/pr-readiness.yaml
+++ b/.github/workflows/pr-readiness.yaml
@@ -26,9 +26,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Dry-run: render to the job summary instead of commenting/drafting.
-  # Flip to "false" to go live.
-  DRY_RUN: "true"
+  # Dry-run: set to "true" to render to the job summary instead of
+  # commenting/drafting.
+  DRY_RUN: "false"
 
 jobs:
   assess:


### PR DESCRIPTION
### Motivation

The PR readiness helper merged with `DRY_RUN: "true"` so its decisions could be verified from job summaries on real PRs before it started posting. This PR takes it live.

### Modifications

- Flip `DRY_RUN` from `"true"` to `"false"` in `.github/workflows/pr-readiness.yaml`, so the helper now posts its sticky comment and moves not-ready PRs to draft instead of only rendering to the job summary.
- Update the README's "Dry run & rollout" section to describe dry-run as a testing tool rather than a pending rollout step.

### Verification

No logic changes — the flag is read by the existing, unit-tested workflow steps, and the dry-run phase exercised the same code path end to end on real PRs.

### Documentation

`.github/pr-readiness/README.md` updated to match the live state.

### AI

This PR was prepared with Claude Code (workflow edit, README update, and this description).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYsLgxBxPGMmJYyfmXdvaJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled live pull request comments and draft conversion by default in the readiness workflow.
  - Added guidance for enabling dry-run mode when simulated results are preferred.

- **Documentation**
  - Updated dry-run documentation to describe simulated comments and decisions shown in the workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->